### PR TITLE
86 set java build version in only one place

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,11 +23,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Get Java Version
-        run: echo ::set-env name=JAVA_VERSION::$(mvn help:evaluate "-Dexpression=maven.compiler.release" -q -DforceStdout)
+        run: |
+          Java_Version=$(mvn help:evaluate "-Dexpression=maven.compiler.release" -q -DforceStdout | sed -e 's/^1\./1.0./')
+          echo "Java_Version=$Java_Version" >> $GITHUB_ENV
       - name: Set up JDK 19
         uses: actions/setup-java@v3
         with:
-          java-version: ${{ env.JAVA_VERSION}
+          java-version: ${{ env.Java_Version }}
           distribution: 'temurin'
           cache: maven
       - name: Compile with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,11 +8,12 @@
 
 name: Java CI with Maven
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: workflow_dispatch
+  #push:
+  #  branches: [ "main" ]
+  #pull_request:
+  #  branches: [ "main" ]
+
 
 jobs:
   build:
@@ -21,10 +22,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Get Java Version
+        run: echo ::set-env name=JAVA_VERSION::$(mvn help:evaluate "-Dexpression=maven.compiler.release" -q -DforceStdout)
       - name: Set up JDK 19
         uses: actions/setup-java@v3
         with:
-          java-version: '19'
+          java-version: ${{ env.JAVA_VERSION}
           distribution: 'temurin'
           cache: maven
       - name: Compile with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,11 +8,11 @@
 
 name: Java CI with Maven
 
-on: workflow_dispatch
-  #push:
-  #  branches: [ "main" ]
-  #pull_request:
-  #  branches: [ "main" ]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+      - name: Get Java Version
+        run: |
+          Java_Version=$(mvn help:evaluate "-Dexpression=maven.compiler.release" -q -DforceStdout | sed -e 's/^1\./1.0./')
+          echo "Java_Version=$Java_Version" >> $GITHUB_ENV
       - name: Set up JDK 19
         uses: actions/setup-java@v3
         with:
-          java-version: '19'
+          java-version: ${{ env.Java_Version }}
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,10 +13,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Get Java Version
+        run: |
+          Java_Version=$(mvn help:evaluate "-Dexpression=maven.compiler.release" -q -DforceStdout | sed -e 's/^1\./1.0./')
+          echo "Java_Version=$Java_Version" >> $GITHUB_ENV
       - name: Set up JDK 19
         uses: actions/setup-java@v3
         with:
-          java-version: 19
+          java-version: ${{ env.Java_Version }}
           distribution: 'temurin'
           cache: maven
       - name: Cache SonarCloud packages

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,7 @@
   <artifactId>haze</artifactId>
   <version>2.0.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>19</maven.compiler.source>
-    <maven.compiler.target>19</maven.compiler.target>
+    <maven.compiler.release>19</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.organization>fungover</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
Instead of having to update multiple files to upgrade our java version, now we only need to do it in our pom.xml file. In pom.xml we now use maven.compiler.release instead of maven.compiler.source and .target. In our yml files they now read our pom.xml file and saves the number defined in our maven.compiler.release, saves it to a enviroment variable and then uses it to define what java version we want.

This only works in default branch, which is why i tried in another project. 
![Screenshot 2023-02-14 at 16 14 25](https://user-images.githubusercontent.com/92143166/218781877-f64929cc-2ea5-4647-a89d-c82b6b50dbbe.jpg)

Here we see that the command is run to save the java version, and also that set up jdk uses java 19 which is our expected result.